### PR TITLE
Make fails with mtime >=2

### DIFF
--- a/aoc.opam
+++ b/aoc.opam
@@ -24,7 +24,7 @@ depends: [
   "eio"
   "eio_main"
   "logs"
-  "mtime"
+  "mtime" {< "2.0.0"}
 ]
 build: []
 install: []


### PR DESCRIPTION
```
$ make
File "lib/misc.ml", line 17, characters 9-16:
17 |   if m < ms_to_s then
              ^^^^^^^
Error: Unbound value ms_to_s
make: *** [Makefile:3: all] Error 1
```

With mtime v1.4.0 (the final pre-v2 version) the project builds successfully. You do however get the following alerts of on the first run of make:
```
$ make
File "lib/misc.ml", line 17, characters 9-16:
17 |   if m < ms_to_s then
              ^^^^^^^
Alert deprecated: Mtime.ms_to_s
Use 1e-3 instead.
File "lib/misc.ml", line 20, characters 21-28:
20 |     let us = span /. us_to_s in
                          ^^^^^^^
Alert deprecated: Mtime.us_to_s
Use 1e-6 instead.
File "lib/misc.ml", line 27, characters 21-28:
27 |     let ms = span /. ms_to_s in
                          ^^^^^^^
Alert deprecated: Mtime.ms_to_s
Use 1e-3 instead.
File "lib/misc.ml", line 31, characters 14-22:
31 |   else if m < min_to_s then
                   ^^^^^^^^
Alert deprecated: Mtime.min_to_s
Use 60. instead.
File "lib/misc.ml", line 41, characters 8-17:
41 |     m < hour_to_s
             ^^^^^^^^^
Alert deprecated: Mtime.hour_to_s
Use 3600. instead.
File "lib/misc.ml", line 43, characters 36-44:
43 |     let m, rem = (truncate (span /. min_to_s), mod_float span min_to_s) in
                                         ^^^^^^^^
Alert deprecated: Mtime.min_to_s
Use 60. instead.
File "lib/misc.ml", line 43, characters 62-70:
43 |     let m, rem = (truncate (span /. min_to_s), mod_float span min_to_s) in
                                                                   ^^^^^^^^
Alert deprecated: Mtime.min_to_s
Use 60. instead.
File "lib/misc.ml", line 47, characters 14-22:
47 |   else if m < day_to_s then
                   ^^^^^^^^
Alert deprecated: Mtime.day_to_s
Use 86_400. instead.
File "lib/misc.ml", line 48, characters 36-45:
48 |     let h, rem = (truncate (span /. hour_to_s), mod_float span hour_to_s) in
                                         ^^^^^^^^^
Alert deprecated: Mtime.hour_to_s
Use 3600. instead.
File "lib/misc.ml", line 48, characters 63-72:
48 |     let h, rem = (truncate (span /. hour_to_s), mod_float span hour_to_s) in
                                                                    ^^^^^^^^^
Alert deprecated: Mtime.hour_to_s
Use 3600. instead.
File "lib/misc.ml", line 49, characters 29-37:
49 |     let m = truncate (rem /. min_to_s) in
                                  ^^^^^^^^
Alert deprecated: Mtime.min_to_s
Use 60. instead.
File "lib/misc.ml", line 52, characters 14-23:
52 |   else if m < year_to_s then
                   ^^^^^^^^^
Alert deprecated: Mtime.year_to_s
Use 31_557_600. instead.
File "lib/misc.ml", line 53, characters 36-44:
53 |     let d, rem = (truncate (span /. day_to_s), mod_float span day_to_s) in
                                         ^^^^^^^^
Alert deprecated: Mtime.day_to_s
Use 86_400. instead.
File "lib/misc.ml", line 53, characters 62-70:
53 |     let d, rem = (truncate (span /. day_to_s), mod_float span day_to_s) in
                                                                   ^^^^^^^^
Alert deprecated: Mtime.day_to_s
Use 86_400. instead.
File "lib/misc.ml", line 54, characters 29-38:
54 |     let h = truncate (rem /. hour_to_s) in
                                  ^^^^^^^^^
Alert deprecated: Mtime.hour_to_s
Use 3600. instead.
File "lib/misc.ml", line 58, characters 36-45:
58 |     let y, rem = (truncate (span /. year_to_s), mod_float span year_to_s) in
                                         ^^^^^^^^^
Alert deprecated: Mtime.year_to_s
Use 31_557_600. instead.
File "lib/misc.ml", line 58, characters 63-72:
58 |     let y, rem = (truncate (span /. year_to_s), mod_float span year_to_s) in
                                                                    ^^^^^^^^^
Alert deprecated: Mtime.year_to_s
Use 31_557_600. instead.
File "lib/misc.ml", line 59, characters 29-37:
59 |     let d = truncate (rem /. day_to_s) in
                                  ^^^^^^^^
Alert deprecated: Mtime.day_to_s
Use 86_400. instead.
```