### PR TITLE
Constrain version of cohttp-eio because of build error.

### DIFF
--- a/aoc.opam
+++ b/aoc.opam
@@ -17,7 +17,7 @@ depends: [
   "bos"
   "fpath"
   "cohttp"
-  "cohttp-eio"
+  "cohttp-eio" {< "6.0.0~alpha1"}
   "tls-eio"
   "uri"
   "mirage-crypto-rng-eio"


### PR DESCRIPTION
```
File "lib/fetch.ml", line 27, characters 41-53:
27 |     Cohttp_eio.Client.get ~headers ~conn (host, None) (Uri.path_and_query uri)
                                              ^^^^^^^^^^^^
Error: This expression has type 'a * 'b
       but an expression was expected of type
         < net : Eio.Net.t; .. > Cohttp_eio.Client.env
make: *** [all] Error 1
```